### PR TITLE
Feature/snackbar update

### DIFF
--- a/client/components/common/SnackBarNotification.tsx
+++ b/client/components/common/SnackBarNotification.tsx
@@ -5,45 +5,50 @@ import Alert from '@mui/material/Alert';
 /**
  * A functional component that displays a notification using MUI Snackbar and Alert components.
  * The Snackbar has 3 ways to close:
- * 1.It will auto close after 6 seconds,
- * 2.By clicking the X icon
- * 3.By pressing the ESC key.
+ * 1. It will auto close after {duration} miliseconds - default is 4000ms
+ * 2. By clicking the X icon
+ * 3. By pressing the ESC key.
  *
  * @param {object} props - The properties passed to the component.
  * @param {boolean} props.open - Indicates if the snackbar is open.
  * @param {string} props.message - The message to be displayed in the alert.
  * @param {'error' | 'warning' | 'info' | 'success'} props.severity - The severity level of the alert.
+ * @param {number} props.duration - The time in miliseconds that the alert remains visible.
+ * @param {function} props.callerUpdater - A callback passed from the caller, which updates the 'alert is open' state on the caller
  * @returns {JSX.Element} The rendered component.
  */
+
+type SnackBarNotificationProps = {
+  open: boolean,
+  message: string,
+  severity: 'error' | 'warning' | 'info' | 'success',
+  duration?: number,
+  callerUpdater: () => void
+}
 
 export default function SnackBarNotification({
   open,
   message,
   severity,
-}: {
-  open: boolean;
-  message: string;
-  severity: 'error' | 'warning' | 'info' | 'success';
-}) {
-  const [isOpen, setOpen] = React.useState(open);
-  //the snackbar has 3 ways to close will close after 6 seconds or by clicking X icon or pressing ESC key
-  const handleClose = (
-    event?: React.SyntheticEvent | Event,
-    reason?: string
-  ) => {
+  duration,
+  callerUpdater
+}: SnackBarNotificationProps) {
+
+  const handleClose = (event?: React.SyntheticEvent | Event, reason?: string) => {
     event?.preventDefault();
     if (reason === 'clickaway') {
       return;
     }
-    setOpen(false);
-  };
+    callerUpdater();
+  }
+
   return (
     <Snackbar
-      open={isOpen}
-      autoHideDuration={6000}
-      onClose={handleClose}
+      open={open}
+      autoHideDuration={duration || 4000}
       anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
       sx={{ minWidth: 500 }}
+      onClose={handleClose}
     >
       <Alert
         onClose={handleClose}

--- a/client/components/common/SnackBarNotification.tsx
+++ b/client/components/common/SnackBarNotification.tsx
@@ -19,28 +19,30 @@ import Alert from '@mui/material/Alert';
  */
 
 type SnackBarNotificationProps = {
-  open: boolean,
-  message: string,
-  severity: 'error' | 'warning' | 'info' | 'success',
-  duration?: number,
-  callerUpdater: () => void
-}
+  open: boolean;
+  message: string;
+  severity: 'error' | 'warning' | 'info' | 'success';
+  duration?: number;
+  callerUpdater: () => void;
+};
 
 export default function SnackBarNotification({
   open,
   message,
   severity,
   duration,
-  callerUpdater
+  callerUpdater,
 }: SnackBarNotificationProps) {
-
-  const handleClose = (event?: React.SyntheticEvent | Event, reason?: string) => {
+  const handleClose = (
+    event?: React.SyntheticEvent | Event,
+    reason?: string
+  ) => {
     event?.preventDefault();
     if (reason === 'clickaway') {
       return;
     }
     callerUpdater();
-  }
+  };
 
   return (
     <Snackbar

--- a/client/components/layout/MainLayout.tsx
+++ b/client/components/layout/MainLayout.tsx
@@ -22,6 +22,7 @@ import {
   SettingsOutlined,
 } from '@mui/icons-material';
 import '@client/styles/MainLayout.css';
+import SnackBar from '../common/SnackBarNotification';
 
 /**
  * MainLayout manages the app's global layout, using `useDynamicNavigation` for route-based UI adjustments. It presents a consistent header featuring the LinktaLogo, with the top navigation bar and footer rendered conditionally as dictated by the current route's needs.
@@ -32,6 +33,12 @@ import '@client/styles/MainLayout.css';
 const MainLayout: React.FC = () => {
   // const { showTopNavBar, showFooter } = useDynamicNavigation();
   const [open, setOpen] = useState(true);
+  const [alertState, setAlertState] = useState(false);
+
+  const updateAlertState = () => {
+    setAlertState(false);
+  }
+
   const toggleDrawer = (newOpen: boolean) => () => {
     setOpen(newOpen);
   };
@@ -100,6 +107,13 @@ const MainLayout: React.FC = () => {
 
       <Button
         className="drawer-close-button"
+        onClick={() => setAlertState(true)}
+        startIcon={<ChevronLeftOutlined />}
+        sx={{ marginBottom: '20px', paddingInline: '20px' }}
+      ><Typography color='white'>TEST SNACK BAR</Typography></Button>
+
+      <Button
+        className="drawer-close-button"
         onClick={toggleDrawer(false)}
         startIcon={<ChevronLeftOutlined />}
         sx={{ marginBottom: '20px', paddingInline: '20px' }}
@@ -109,6 +123,14 @@ const MainLayout: React.FC = () => {
 
   return (
     <>
+      <SnackBar
+        open={alertState}
+        message='TEST ALERT MESSAGE!!!'
+        severity='info'
+        duration={2000}
+        callerUpdater={updateAlertState}
+        />
+
       {/* this Box creates the Linkta background color layer */}
       <Box className="background-color"></Box>
 

--- a/client/components/layout/MainLayout.tsx
+++ b/client/components/layout/MainLayout.tsx
@@ -22,7 +22,6 @@ import {
   SettingsOutlined,
 } from '@mui/icons-material';
 import '@client/styles/MainLayout.css';
-import SnackBar from '../common/SnackBarNotification';
 
 /**
  * MainLayout manages the app's global layout, using `useDynamicNavigation` for route-based UI adjustments. It presents a consistent header featuring the LinktaLogo, with the top navigation bar and footer rendered conditionally as dictated by the current route's needs.
@@ -33,12 +32,6 @@ import SnackBar from '../common/SnackBarNotification';
 const MainLayout: React.FC = () => {
   // const { showTopNavBar, showFooter } = useDynamicNavigation();
   const [open, setOpen] = useState(true);
-  const [alertState, setAlertState] = useState(false);
-
-  const updateAlertState = () => {
-    setAlertState(false);
-  }
-
   const toggleDrawer = (newOpen: boolean) => () => {
     setOpen(newOpen);
   };
@@ -107,13 +100,6 @@ const MainLayout: React.FC = () => {
 
       <Button
         className="drawer-close-button"
-        onClick={() => setAlertState(true)}
-        startIcon={<ChevronLeftOutlined />}
-        sx={{ marginBottom: '20px', paddingInline: '20px' }}
-      ><Typography color='white'>TEST SNACK BAR</Typography></Button>
-
-      <Button
-        className="drawer-close-button"
         onClick={toggleDrawer(false)}
         startIcon={<ChevronLeftOutlined />}
         sx={{ marginBottom: '20px', paddingInline: '20px' }}
@@ -123,14 +109,6 @@ const MainLayout: React.FC = () => {
 
   return (
     <>
-      <SnackBar
-        open={alertState}
-        message='TEST ALERT MESSAGE!!!'
-        severity='info'
-        duration={2000}
-        callerUpdater={updateAlertState}
-        />
-
       {/* this Box creates the Linkta background color layer */}
       <Box className="background-color"></Box>
 


### PR DESCRIPTION
<!--# Pull Request Template -->
Our modular, re-usable Snack Bar notification is a bit different from the examples in the MUI docs. Because our Snack Bar can be triggered from any currently rendered element, it must be controlled by a state variable on that rendered element. To account for this we pass a `callerUpdater()` callback to the Snack Bar as a required prop. 

Also added an optional `duration` prop. If a value is provided, it will override the default value. The default value has been adjusted from 6000ms to 4000ms.

<!--
Please include a summary of the change and which issue is fixed. Include relevant motivation and context. List any dependencies that are required for this change.

Linking Issues:
 - To associate this pull request with a GitHub issue within the same repository, use the "Fixes #IssueNumber" syntax.
 - For external issues, use Markdown links: [Issue Name](Issue Link).
-->

Fixes #84 

## Type of change

<!--Please delete options that are not relevant.-->

- [x]  🐛 Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

<!--Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Remove if not applicable. -->

- [x] N/A

## Checklist:

<!--Before submitting your pull request, please review the following checklist:-->

- [x] I have performed a self-review of my own code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have reviewed the [**Security Best Practices Document**](./docs/SECURITY_BEST_PRACTICES.md).
- [ ] I have followed the [**Naming Conventions Guide**](./docs/NAMING_CONVENTIONS_GUIDE.md) for my changes.
- [x] I have ensured that my pull request title is descriptive.
