### PR TITLE
feature/title adds useDocumentTitle custom hook to set document title & sample usage #105

### DIFF
--- a/client/components/prompt-input/PromptInputPage.tsx
+++ b/client/components/prompt-input/PromptInputPage.tsx
@@ -2,8 +2,10 @@ import { Box } from '@mui/material';
 import React from 'react';
 import PromptInputForm from './PromptInputForm';
 import PromptInputInstructions from './PromptInputInstructions';
+import useDocumentTitle from '@/client/hooks/useDocumentTitle';
 
 const PromptInputPage = () => {
+  useDocumentTitle('Prompt');
   return (
     <Box className="prompt-input-view">
       <PromptInputForm />

--- a/client/features/auth-pages/SignInPage.tsx
+++ b/client/features/auth-pages/SignInPage.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
+import useDocumentTitle from '@/client/hooks/useDocumentTitle';
 
 const SignInPage = () => {
+  useDocumentTitle('Sign in');
   return <div>SignInPage</div>;
 };
 

--- a/client/features/help-and-feedback-page/HelpAndFeedbackPage.tsx
+++ b/client/features/help-and-feedback-page/HelpAndFeedbackPage.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
+import useDocumentTitle from '@/client/hooks/useDocumentTitle';
 
 const HelpAndFeedback = () => {
+  useDocumentTitle('Feedback');
   return <div>Help and Feedback Placeholder</div>;
 };
 

--- a/client/features/home-page/HomePage.tsx
+++ b/client/features/home-page/HomePage.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
 import HomePageMainHero from './components/HomePageMainHero';
 import HomePageTreeVisualizationPanel from './components/HomePageTreeVisualizationPanel';
+import useDocumentTitle from '@/client/hooks/useDocumentTitle';
 
 const HomePage = () => {
+  useDocumentTitle();
   return (
     <>
       <HomePageMainHero />

--- a/client/features/settings-page/Settings.tsx
+++ b/client/features/settings-page/Settings.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
+import useDocumentTitle from '@/client/hooks/useDocumentTitle';
 
 const Settings = () => {
+  useDocumentTitle('Settings');
   return <div>Settings Placeholder</div>;
 };
 

--- a/client/hooks/useDocumentTitle.ts
+++ b/client/hooks/useDocumentTitle.ts
@@ -1,0 +1,18 @@
+import { useEffect } from 'react';
+
+/**
+ * Custom hook to set the document title based on the provided view name.
+ * This hook should be used by any component that will be rendered as a page
+ * when a route is visited. If a view name is provided, it appends the view
+ * name to "Linkta". If no view name is provided, it defaults to "Linkta".
+ *
+ * @param {string} [view] - The name of the current view to be appended to the document title.
+ */
+
+const useDocumentTitle = (view?: string) => {
+  useEffect(() => {
+    document.title = view ? `${view} | Linkta` : 'Linkta';
+  }, [view]);
+};
+
+export default useDocumentTitle;


### PR DESCRIPTION
## Description

- Adds a custom hook for setting document title
- includes sample usage for all current pages with clickable routes. 

## Type of change

Fixes #105 

- [x] ✨  New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Manual Testing

## Checklist:

- [x] I have performed a self-review of my own code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [x] I have reviewed the [**Security Best Practices Document**](./docs/SECURITY_BEST_PRACTICES.md).
- [x] I have followed the [**Naming Conventions Guide**](./docs/NAMING_CONVENTIONS_GUIDE.md) for my changes.
- [x] I have ensured that my pull request title is descriptive.

## Additional Information:

I chose to dynamically set the documents title at the component level. Any component that will be rendered as a page must use the useDocumentTitle hook to properly set the pages title. 
