### PR TITLE
Hotfix: update precommit hook to exit if prettier warnings are thrown

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -24,3 +24,6 @@ cd ..
 cd server 
 # npm run format - to be added back in future PR
 npm run lint
+
+# Confirm pre-commit hook ran before completing commit
+echo 'Pre-commit hook ran successfully with no TypeScript or linting errors detected.'

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -15,7 +15,12 @@ if [ $CLIENT_TSC -ne 0 ] || [ $SERVER_TSC -ne 0 ]; then
   exit 1
 fi
 
-# If tsc passes, then run lint-staged
-cd client && npm run lint && npm run format
+# If tsc passes, then run linting in each directory.
+# If warnings or errors are thrown, husky process should exit without committing.
+cd client 
+# run format - to be added back in future PR
+npm run lint
 cd ..
-cd server && npm run lint && npm run format
+cd server 
+# npm run format - to be added back in future PR
+npm run lint


### PR DESCRIPTION
<!--# Pull Request Template -->


<!--
Please include a summary of the change and which issue is fixed. Include relevant motivation and context. List any dependencies that are required for this change.

Linking Issues:
 - To associate this pull request with a GitHub issue within the same repository, use the "Fixes #IssueNumber" syntax.
 - For external issues, use Markdown links: [Issue Name](Issue Link).
-->

## Description

Partially addresses #259 by causing the pre-commit hook to fail if any warnings or errors are thrown by eslint or prettier. The pre-commit file previously used the `&&` operator to run multiple npm commands, which caused some unexpected behavior where a process could fail without causing husky to exit its process. This PR simply moves the commands onto their own lines to prevent this behavior.

The hook <ins>does not</ins> auto-format code in this hotfix. This functionality will be re-introduced in a later PR. For now, if husky does not allow you to commit, please run `npm run format` to fix prettier warnings and manually fix eslint errors before attempting to commit again.

My prio for this PR is to ensure that the hook does not allow warnings to be committed, causing confusion when the contributor successfully makes a commit but still has leftover unstaged changes afterward. 

## Type of change

<!--Please delete options that are not relevant.-->

- [x]  🐛 Bug fix (non-breaking change which fixes an issue)

## How Can this be tested? Testing Plan to review this PR

<!--Please provide a short testing plan for PR reviewers to verify the changes you made actually work and that no new bugs or errors are introduced. Provide simple and specific steps the reviewer can follow to test the changes you made.-->

1. Make a change that would cause a prettier warning, such as changing a set of single quotes to double quotes.
2. Attempt to commit the change. Husky should exit the process without commiting:
`husky - pre-commit script failed (code 1)`
4. Make a change that would cause an eslint error, such as declaring an unused variable.
5. Attempt to commit the change. Husky should exit the process:
`husky - pre-commit script failed (code 2)`


## Checklist:

<!--Before submitting your pull request, please review the following checklist:-->

- [x] I have performed a self-review of my own code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I have reviewed the [**Security Best Practices Document**](./docs/SECURITY_BEST_PRACTICES.md).
- [x] I have followed the [**Naming Conventions Guide**](./docs/NAMING_CONVENTIONS_GUIDE.md) for my changes.
- [x] I have ensured that my pull request title is descriptive.

## Additional Information:

<!--Any additional information, configuration, or data that might be necessary to reproduce the issue or feature.-->
