### PR TITLE
Fix Generate Button bug

### DIFF
--- a/client/components/user-input/UserInputForm.tsx
+++ b/client/components/user-input/UserInputForm.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import type { SubmitHandler } from 'react-hook-form';
 import { Controller, useForm } from 'react-hook-form';
@@ -31,25 +31,17 @@ const UserInputForm = () => {
     reset,
     control,
     watch,
-    formState: { errors, isSubmitted },
+    formState: { errors },
   } = useForm({
     resolver: zodResolver(userInputValidationSchema),
     defaultValues: {
       input: '',
-      isChecked: JSON.parse(localStorage.getItem('isChecked') || 'false'),
+      isChecked: JSON.parse('true' || 'false'),
     },
   });
   const navigate = useNavigate();
   const newUserInputMutation = useNewUserInputMutation();
-  // Here we utilize the watch function to subscribe to checkbox state changes and save those changes to our localStorage.
-  useEffect(() => {
-    const subscription = watch((value, { name }) => {
-      if (name === 'isChecked') {
-        localStorage.setItem('isChecked', value.isChecked);
-      }
-    });
-    return () => subscription.unsubscribe();
-  }, [watch]);
+  const isChecked = watch('isChecked');
 
   const onSubmit: SubmitHandler<CustomFormData> = async (data) => {
     try {
@@ -130,7 +122,7 @@ const UserInputForm = () => {
           variant='contained'
           className={`${styles.userInputSubmitButton}`}
           type='submit'
-          disabled={isSubmitted || !control._formValues.isChecked}
+          disabled={!isChecked}
         >
           {newUserInputMutation.status === 'pending' ? 'Loading' : 'Generate'}
         </Button>


### PR DESCRIPTION
<!--# Pull Request Template -->
## Description

After evaluating the importance of saving our Checkbox state to localStorage, I've decided to simplify its state management using RHF's watch method. Our Generate button is now appropriately enabled/disabled when the Checkbox is ticked/unticked. I also removed the isSubmitted condition from the button's disabled prop so we don't have to keep refreshing the page every time our request errors out. 

Fixes #296 

## Type of change

<!--Please delete options that are not relevant.-->

- [x]  🐛 Bug fix (non-breaking change which fixes an issue)

## How Can this be tested? Testing Plan to review this PR

<!--Please provide a short testing plan for PR reviewers to verify the changes you made actually work and that no new bugs or errors are introduced. Provide simple and specific steps the reviewer can follow to test the changes you made.-->

Click on "Explore a New Topic" to navigate to our UserInputForm page and click on the checkbox underneath the input bar. When it's ticked, the Generate button should be enabled for submission; when it's unticked, the button should be disabled/greyed out. 

## Checklist:

<!--Before submitting your pull request, please review the following checklist:-->

- [x] I have performed a self-review of my own code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have reviewed the [**Security Best Practices Document**](./docs/SECURITY_BEST_PRACTICES.md).
- [ ] I have followed the [**Naming Conventions Guide**](./docs/NAMING_CONVENTIONS_GUIDE.md) for my changes.
- [x] I have ensured that my pull request title is descriptive.

## Additional Information:

<!--Any additional information, configuration, or data that might be necessary to reproduce the issue or feature.-->
