### PR TITLE
Correct Linkta logo png reference path in MainLayout; Improve server logging config

### DIFF
--- a/client/components/layout/MainLayout.tsx
+++ b/client/components/layout/MainLayout.tsx
@@ -75,7 +75,7 @@ const MainLayout: React.FC = () => {
         >
           <img
             className={`linkta-logo-image ${drawerOpen ? 'layout-open' : 'layout-closed'}`}
-            src='../assets/linkta-logo-web.png'
+            src='/linkta-logo-web.png'
             alt='The Linkta.io logo at approximately 50 pixels square, located in the upper-left corner of the page.'
           />
         </Box>

--- a/server/utils/log4js.config.json
+++ b/server/utils/log4js.config.json
@@ -4,7 +4,7 @@
       "type": "stdout",
       "layout": {
         "type": "pattern",
-        "pattern": "%[%d{yyyy-MM-dd hh:mm:ss:SSS} [%p] %c %f{2} %l:%o %F%] %m"
+        "pattern": "%[%d{yyyy-MM-dd hh:mm:ss:SSS} [%p] %c %f{2} %l:%o %F%]%n %m%n"
       }
     }
   },


### PR DESCRIPTION
<!--# Pull Request Template -->
## Description
This is a follow-up to PR #286 with one additional change to update an image reference path.
Also added newlines to the server logs to create visual separation. 

![image](https://github.com/Linkta-org/core/assets/71753585/a1030568-7017-40c0-876d-a863c4978a60)


<!--
Please include a summary of the change and which issue is fixed. Include relevant motivation and context. List any dependencies that are required for this change.

Linking Issues:
 - To associate this pull request with a GitHub issue within the same repository, use the "Fixes #IssueNumber" syntax.
 - For external issues, use Markdown links: [Issue Name](Issue Link).
-->

Fixes # N/A

## Type of change

<!--Please delete options that are not relevant.-->

- [x] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Can this be tested? Testing Plan to review this PR

<!--Please provide a short testing plan for PR reviewers to verify the changes you made actually work and that no new bugs or errors are introduced. Provide simple and specific steps the reviewer can follow to test the changes you made.-->




## Checklist:

<!--Before submitting your pull request, please review the following checklist:-->

- [x] I have performed a self-review of my own code.
- [x] I have ensured that my pull request title is descriptive.

