### PR TITLE
Update auth middleware and environment files

### DIFF
--- a/server/middleware/firebaseAuthMiddleware.ts
+++ b/server/middleware/firebaseAuthMiddleware.ts
@@ -5,10 +5,10 @@ import type {
   Response,
   NextFunction,
 } from 'express';
-import { getServiceAccountEnv } from '@utils/environment';
+import { getEnv } from '@utils/environment';
 import log4js from 'log4js';
 
-getServiceAccountEnv();
+getEnv();
 
 const { getLogger } = log4js;
 const logger = getLogger('[USER AUTH]');

--- a/server/utils/environment.ts
+++ b/server/utils/environment.ts
@@ -14,17 +14,3 @@ export function getEnv(): void {
 
   dotenv.config(envConfig);
 }
-
-/**
- * Get environment variables from .env.service-account file in the server root directory.
- */
-export function getServiceAccountEnv(): void {
-  const projectRoot = process.cwd();
-  const envPath = resolve(projectRoot, '.env.service-account');
-
-  const envServiceAccountConfig = {
-    path: envPath,
-  };
-
-  dotenv.config(envServiceAccountConfig);
-}


### PR DESCRIPTION
<!--# Pull Request Template -->
During development of the Linkta authentication / authorization features, I created a separate .env file to contain the Firebase Service Account values. In hindsight, this was redundant and added unnecessary complexity to the project and to the onboarding process for new developers.

This PR simplifies the server-side environment so that all environment variables are maintained in the .env file. 

The PROJECT_ID, PRIVATE_KEY, and CLIENT_EMAIL variables should be moved from local .env.service-account into the local .env file.

The local .env.service-account file should be deleted if present.

<!--
Please include a summary of the change and which issue is fixed. Include relevant motivation and context. List any dependencies that are required for this change.

Linking Issues:
 - To associate this pull request with a GitHub issue within the same repository, use the "Fixes #IssueNumber" syntax.
 - For external issues, use Markdown links: [Issue Name](Issue Link).
-->

Fixes # N/A

## Type of change

<!--Please delete options that are not relevant.-->

- [x] ✨  New feature (non-breaking change which adds functionality)

## How Can this be tested? Testing Plan to review this PR

<!--Please provide a short testing plan for PR reviewers to verify the changes you made actually work and that no new bugs or errors are introduced. Provide simple and specific steps the reviewer can follow to test the changes you made.-->

- [x] Where in the app does this change take place? | server-side .env configuration
- [x] What are the steps to test this change? | Run the client and server, sign in and sign out.
- [x] What is the expected output? | No errors in the console relating to missing environment variables


## Checklist:

<!--Before submitting your pull request, please review the following checklist:-->

- [x] I have performed a self-review of my own code.
- [x] I have ensured that my pull request title is descriptive.

