### PR TITLE
Refactor: Replace Throttle with Debounce for LinktaFlow Generation

### DIFF
--- a/client/components/user-input/UserInputForm.tsx
+++ b/client/components/user-input/UserInputForm.tsx
@@ -50,6 +50,7 @@ const UserInputForm = () => {
 
   const onSubmit = useCallback(
     async (data: CustomFormData) => {
+      setLoading(true);
       try {
         const response = await createLinktaFlowMutation.mutateAsync({
           input: data.input,
@@ -58,10 +59,10 @@ const UserInputForm = () => {
         reset();
         navigate(`/output/${response.userInputId}`);
         showNotification('LinktaFlow created successfully.', 'success');
-    } catch (error) {
+      } catch (error) {
         console.error('Failed to create LinktaFlow: ', error);
         let errorMessage =
-        'Unable to create LinktaFlow. Please check your input and try again.';
+          'Unable to create LinktaFlow. Please check your input and try again.';
 
         if (error instanceof AxiosError && error.response) {
           errorMessage = error.response.data || errorMessage;
@@ -69,21 +70,29 @@ const UserInputForm = () => {
           errorMessage = error.message;
         }
 
-      showNotification(errorMessage, 'error', {
-        duration: 6000,
-        action: {
-          label: 'Retry',
-          onClick: () => handleSubmit(throttledSubmit)(),
-        },
-      });
-    } finally {
-      setLoading(false);
-    }
-  }
+        showNotification(errorMessage, 'error', {
+          duration: 6000,
+          action: {
+            label: 'Retry',
+            onClick: () => handleSubmit(debouncedSubmit)(),
+          },
+        });
+      } finally {
+        setLoading(false);
+      }
     },
+    [
+      createLinktaFlowMutation,
+      queryClient,
+      reset,
+      navigate,
+      showNotification,
+      setLoading,
+      handleSubmit,
+    ],
   );
 
-  const debouncedSubmit = useDebounce(onSubmit, 1000);
+  const debouncedSubmit = useDebounce(onSubmit, 500);
 
   return (
     <>

--- a/client/components/user-input/UserInputForm.tsx
+++ b/client/components/user-input/UserInputForm.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Controller, useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -14,7 +14,7 @@ import {
 import styles from '@styles/UserInputView.module.css';
 import { useCreateLinktaFlowMutation } from '@/hooks/useCreateLinktaFlowMutation';
 import { useQueryClient } from '@tanstack/react-query';
-import useThrottle from '@hooks/useThrottle';
+import useDebounce from '@hooks/useDebounce';
 import { AxiosError } from 'axios';
 import Loader from '@/components/common/Loader';
 import useUserInputStore from '@/stores/UserInputStore';
@@ -48,28 +48,26 @@ const UserInputForm = () => {
   const isLoading = useLoadingStore((state) => state.isLoading);
   const setLoading = useLoadingStore((state) => state.setLoading);
 
-  const throttledSubmit = useThrottle(async (data: CustomFormData) => {
-    setLoading(true);
-    try {
-      const response = await createLinktaFlowMutation.mutateAsync({
-        input: data.input,
-      });
-      await queryClient.invalidateQueries({ queryKey: ['inputHistory'] });
-      reset();
-      navigate(`/output/${response.userInputId}`);
-      setLoading(false);
-      showNotification('LinktaFlow created successfully.', 'success');
+  const onSubmit = useCallback(
+    async (data: CustomFormData) => {
+      try {
+        const response = await createLinktaFlowMutation.mutateAsync({
+          input: data.input,
+        });
+        await queryClient.invalidateQueries({ queryKey: ['inputHistory'] });
+        reset();
+        navigate(`/output/${response.userInputId}`);
+        showNotification('LinktaFlow created successfully.', 'success');
     } catch (error) {
-      setLoading(false);
-      console.error('Failed to create LinktaFlow: ', error);
-      let errorMessage =
+        console.error('Failed to create LinktaFlow: ', error);
+        let errorMessage =
         'Unable to create LinktaFlow. Please check your input and try again.';
 
-      if (error instanceof AxiosError && error.response) {
-        errorMessage = error.response.data || errorMessage;
-      } else if (error instanceof Error) {
-        errorMessage = error.message;
-      }
+        if (error instanceof AxiosError && error.response) {
+          errorMessage = error.response.data || errorMessage;
+        } else if (error instanceof Error) {
+          errorMessage = error.message;
+        }
 
       showNotification(errorMessage, 'error', {
         duration: 6000,
@@ -81,7 +79,11 @@ const UserInputForm = () => {
     } finally {
       setLoading(false);
     }
-  }, 1000);
+  }
+    },
+  );
+
+  const debouncedSubmit = useDebounce(onSubmit, 1000);
 
   return (
     <>
@@ -89,7 +91,7 @@ const UserInputForm = () => {
         <Loader />
       ) : (
         <form
-          onSubmit={handleSubmit(throttledSubmit)}
+          onSubmit={handleSubmit(debouncedSubmit)}
           className={`${styles.userInputForm}`}
         >
           <Typography

--- a/client/hooks/useDebounce.ts
+++ b/client/hooks/useDebounce.ts
@@ -1,0 +1,33 @@
+import { useCallback, useRef } from 'react';
+
+/**
+ * Custom hook to debounce a function
+ * @param callback - The function to be debounced.
+ * @param delay - The delay in milliseconds for debouncing.
+ * @returns A debounced version of the callback function.
+ */
+const useDebounce = <T extends unknown[]>(
+  callback: (...args: T) => void,
+  delay: number,
+): ((...args: T) => void) => {
+  // Ref to store the timeout ID
+  const timeoutRef = useRef<NodeJS.Timeout | null>(null);
+
+  return useCallback(
+    (...args: T) => {
+      // Clear the previous timeout if it exists
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+
+      // Set a new timeout
+      timeoutRef.current = setTimeout(() => {
+        timeoutRef.current = null; // Reset the timeoutId before execution
+        callback.apply(this, args);
+      }, delay);
+    },
+    [callback, delay],
+  );
+};
+
+export default useDebounce;


### PR DESCRIPTION
<!--# Pull Request Template -->
## Description
- Created a new `useDebounce` hook
- Replaced `useThrottle` with a new `useDebounce` hook in `UserInputForm` & `PopularTopics`

## Rationale
The previous throttling implementation didn't suit our app's needs because it allowed unintended submissions and didn't effectively prevent rapid consecutive calls. Switching to debouncing addresses these issues, ensuring only one API call after user input stabilizes. [Reference](https://css-tricks.com/debouncing-throttling-explained-examples/)

## Type of change
- [X] Other 🗒️ Refactor

## How Can this be tested? Testing Plan to review this PR
- At root dir, run `npm run dev`
- **UserInputForm**
- Comment out all the code related to the loading state/loader (lines 19, 21, 48, 49, 53, 81, 90, 99-101, 152).
- Type in a query and click the `generate` button for 10+ times continuously
- Observe: only 1 linktaFlow is created after consecutive button clicks are stopped

- **PopularTopics**
- Comment out all the code related to the loading state/loader (lines 8, 29, 30, 35, 62, 70, 91
- Click a topic for 10+ times continuously
- Observe: only 1 linktaFlow is created after consecutive button clicks are stopped

## Checklist:

<!--Before submitting your pull request, please review the following checklist:-->

- [X] I have performed a self-review of my own code.
- [X] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [X] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [X] I have reviewed the [**Security Best Practices Document**](./docs/SECURITY_BEST_PRACTICES.md).
- [X] I have followed the [**Naming Conventions Guide**](./docs/NAMING_CONVENTIONS_GUIDE.md) for my changes.
- [X] I have ensured that my pull request title is descriptive.
