### PR TITLE
refactor: set initalNodes and initalEdges to empty arrays

### DIFF
--- a/client/features/output-visualization-page/components/Flow.tsx
+++ b/client/features/output-visualization-page/components/Flow.tsx
@@ -31,34 +31,9 @@ const rfStyle = {
   width: '100%',
 };
 
-const initialNodes = [
-  {
-    id: '1',
-    label: '1',
-    position: { x: 0, y: 0 },
-    data: { label: '😎 drag me around 😎' },
-    type: 'linktaNode',
-  },
-  {
-    id: '2',
-    label: '2',
-    position: { x: 0, y: 150 },
-    data: { label: '...or me' },
-    type: 'linktaNode',
-  },
-];
+const initialNodes: Node[] = [];
 
-const initialEdges = [
-  {
-    id: '1-2',
-    source: '1',
-    target: '2',
-    sourceHandle: 'c',
-    targetHandle: 'a',
-    type: 'linktaEdge',
-    markerEnd: { type: MarkerType.Arrow },
-  },
-];
+const initialEdges: Edge[] = [];
 
 function Flow({ userInputId }: { userInputId: string }) {
   const {


### PR DESCRIPTION
<!--# Pull Request Template -->
## Description

<!--
Please include a summary of the change and which issue is fixed. Include relevant motivation and context. List any dependencies that are required for this change.

Linking Issues:
 - To associate this pull request with a GitHub issue within the same repository, use the "Fixes #IssueNumber" syntax.
 - For external issues, use Markdown links: [Issue Name](Issue Link).
-->

Removes hard coded sample data from initial nodes and edges and sets them to empty arrays when a new LinktaFlow is generated.

Fixes #378 

## Type of change

<!--Please delete options that are not relevant.-->
- [x] Other remove dummy test code

## How Can this be tested? Testing Plan to review this PR

<!--Please provide a short testing plan for PR reviewers to verify the changes you made actually work and that no new bugs or errors are introduced. Provide simple and specific steps the reviewer can follow to test the changes you made.-->

- [x] Where in the app does this change take place?
- Flow.tsx
- [x] What are the steps to test this change?
- run `npm run dev`
- generate new LinktaFlow
- select undo arrow
- [x] What is the expected output?
- All nodes should disappear as arrays are empty


## Checklist:

<!--Before submitting your pull request, please review the following checklist:-->

- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I have reviewed the [**Security Best Practices Document**](./docs/SECURITY_BEST_PRACTICES.md).
- [x] I have followed the [**Naming Conventions Guide**](./docs/NAMING_CONVENTIONS_GUIDE.md) for my changes.
- [x] I have ensured that my pull request title is descriptive.

## Additional Information:

<!--Any additional information, configuration, or data that might be necessary to reproduce the issue or feature.-->
