### PR TITLE
refactor: resets undo/redo states when selecting another LinktaFLow

### DIFF
--- a/client/features/output-visualization-page/components/UndoAndRedo.tsx
+++ b/client/features/output-visualization-page/components/UndoAndRedo.tsx
@@ -3,57 +3,42 @@ import ButtonGroup from '@mui/material/ButtonGroup';
 import IconButton from '@mui/material/IconButton';
 import UndoRoundedIcon from '@mui/icons-material/UndoRounded';
 import RedoRoundedIcon from '@mui/icons-material/RedoRounded';
-
-import { useStoreWithEqualityFn } from 'zustand/traditional';
-import type { TemporalState } from 'zundo';
-import type { LinktaFlowStore } from '@/stores/LinktaFlowStore';
-import useLinktaFlowStore from '@/stores/LinktaFlowStore';
-
-const useTemporalStore = <T,>(
-  selector: (state: TemporalState<LinktaFlowStore>) => T,
-  equality?: (a: T, b: T) => boolean,
-) => useStoreWithEqualityFn(useLinktaFlowStore.temporal, selector, equality);
+import styles from '@styles/UndoAndRedo.module.css';
+import useUndoRedoStore from '@/stores/UndoRedoStore';
 
 const UndoAndRedo = () => {
-  const { undo, redo } = useTemporalStore((state) => state);
+  const { undo, redo, pastStates, futureStates } = useUndoRedoStore(
+    (state) => ({
+      undo: state.undo,
+      redo: state.redo,
+      pastStates: state.pastStates,
+      futureStates: state.futureStates,
+    }),
+  );
 
+  const canUndo = pastStates.length > 0;
+  const canRedo = futureStates.length > 0;
   return (
-    <>
-      <ButtonGroup orientation='vertical'>
-        <IconButton
-          aria-label='undo'
-          size='small'
-          sx={{
-            color: 'black',
-            backgroundColor: '#FFF',
-            '&:hover': { backgroundColor: '#f4f4f4' },
-            border: '0.5px solid #f4f4f4',
-            borderRadius: '0px',
-            width: '26px',
-            height: '26px',
-          }}
-          onClick={() => undo()}
-        >
-          <UndoRoundedIcon fontSize='small' />
-        </IconButton>
-        <IconButton
-          aria-label='redo'
-          size='small'
-          sx={{
-            color: 'black',
-            backgroundColor: '#FFF',
-            '&:hover': { backgroundColor: '#f4f4f4' },
-            border: '0.5px solid #f4f4f4',
-            borderRadius: '0px',
-            width: '26px',
-            height: '26px',
-          }}
-          onClick={() => redo()}
-        >
-          <RedoRoundedIcon fontSize='small' />
-        </IconButton>
-      </ButtonGroup>
-    </>
+    <ButtonGroup orientation='vertical'>
+      <IconButton
+        disabled={!canUndo}
+        aria-label='Undo last action'
+        size='small'
+        className={styles.undoredo_button}
+        onClick={() => undo()}
+      >
+        <UndoRoundedIcon fontSize='small' />
+      </IconButton>
+      <IconButton
+        disabled={!canRedo}
+        aria-label='Redo last action'
+        size='small'
+        className={styles.undoredo_button}
+        onClick={() => redo()}
+      >
+        <RedoRoundedIcon fontSize='small' />
+      </IconButton>
+    </ButtonGroup>
   );
 };
 

--- a/client/stores/LinktaFlowStore.ts
+++ b/client/stores/LinktaFlowStore.ts
@@ -19,7 +19,11 @@ const useLinktaFlowStore = create<LinktaFlowStore>()(
       (set, get) => ({
         currentLinktaFlow: {} as LinktaFlow,
         getCurrentFlow: () => get().currentLinktaFlow,
-        setCurrentFlow: (flow) => set({ currentLinktaFlow: flow }),
+        setCurrentFlow: (flow) => {
+          set({ currentLinktaFlow: flow });
+          // Clear the undo/redo history when a new flow is selected
+          useLinktaFlowStore.temporal.getState().clear();
+        },
         setCurrentNodes: (nodes) => {
           set((state) => ({
             currentLinktaFlow: { ...state.currentLinktaFlow, nodes },

--- a/client/stores/UndoRedoStore.ts
+++ b/client/stores/UndoRedoStore.ts
@@ -1,0 +1,11 @@
+import { useStoreWithEqualityFn } from 'zustand/traditional';
+import type { TemporalState } from 'zundo';
+import useLinktaFlowStore from '@/stores/LinktaFlowStore';
+import type { LinktaFlowStore } from '@/stores/LinktaFlowStore';
+
+const useUndoRedoStore = <T>(
+  selector: (state: TemporalState<LinktaFlowStore>) => T,
+  equality?: (a: T, b: T) => boolean,
+) => useStoreWithEqualityFn(useLinktaFlowStore.temporal, selector, equality);
+
+export default useUndoRedoStore;

--- a/client/styles/UndoAndRedo.module.css
+++ b/client/styles/UndoAndRedo.module.css
@@ -1,0 +1,16 @@
+.undoredo_button {
+  color: black;
+  background-color: #fff;
+  border: 0.5px solid #f4f4f4;
+  border-radius: 0;
+  width: 26px;
+  height: 26px;
+}
+
+.undoredo_button:hover {
+  background-color: #f4f4f4;
+}
+
+.undoredo_button:disabled {
+  background-color: #fff;
+}


### PR DESCRIPTION
<!--# Pull Request Template -->
## Description

<!--
Please include a summary of the change and which issue is fixed. Include relevant motivation and context. List any dependencies that are required for this change.

Linking Issues:
 - To associate this pull request with a GitHub issue within the same repository, use the "Fixes #IssueNumber" syntax.
 - For external issues, use Markdown links: [Issue Name](Issue Link).
-->

This pull request introduces changes to reset the LinktaFlow undo/redo temporal state whenever a new flow is selected. This resolves an issue where selecting `undo` after navigating between flows would render states from previously selected LinktaFlows.

Changes made:
- Updated `setCurrentFlow` to clear the undo/redo history via `temporal.getState().clear()` whenever a different flow is selected.
- Disabled undo/redo buttons when there are no changes in the store.
- moved button styling from inline styles to CSS module
- moved temporal store logic to separate UndoandRedo store file.
  
These changes ensure that each flow starts with a fresh undo/redo history, improving state consistency and overall user experience.

Fixes #371 

## Type of change

<!--Please delete options that are not relevant.-->

- [x]  🐛 Bug fix (non-breaking change which fixes an issue)

## How Can this be tested? Testing Plan to review this PR

<!--Please provide a short testing plan for PR reviewers to verify the changes you made actually work and that no new bugs or errors are introduced. Provide simple and specific steps the reviewer can follow to test the changes you made.-->

- [x] Where in the app does this change take place?
- LinktaFLowStore and UndoAndRedo
- [x] What are the steps to test this change?
- run `npm run dev`
- generate a new LinktaFlow or select one from the side nav
- [x] What is the expected output?
- undo and redo buttons should remain disabled until a node is moved
- previous flows should not remain in  undo history when selecting another flow


## Checklist:

<!--Before submitting your pull request, please review the following checklist:-->

- [x] I have performed a self-review of my own code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I have reviewed the [**Security Best Practices Document**](./docs/SECURITY_BEST_PRACTICES.md).
- [x] I have followed the [**Naming Conventions Guide**](./docs/NAMING_CONVENTIONS_GUIDE.md) for my changes.
- [x] I have ensured that my pull request title is descriptive.

## Additional Information:

<!--Any additional information, configuration, or data that might be necessary to reproduce the issue or feature.-->
