### PR TITLE
Refactor: updated user input from left sidebar with tooltip

### DIFF
--- a/client/components/layout/UserInputList.tsx
+++ b/client/components/layout/UserInputList.tsx
@@ -6,6 +6,7 @@ import {
   ListItemText,
   Typography,
   IconButton,
+  Tooltip,
 } from '@mui/material';
 import MoreVertIcon from '@mui/icons-material/MoreVert';
 import OptionsMenu from './OptionsMenu';
@@ -171,12 +172,30 @@ const UserInputList: React.FC<UserInputListProps> = ({
             >
               <ListItemText
                 primary={
-                  <Typography variant='caption'>{userInput.title}</Typography>
+                  <Tooltip
+                    title={userInput.title}
+                    placement='top'
+                  >
+                    <Typography
+                      variant='caption'
+                      noWrap
+                      sx={{
+                        overflow: 'hidden',
+                        textOverflow: 'ellipsis',
+                        whiteSpace: 'nowrap',
+                        maxWidth: '100%', // Ensure max width to trigger ellipsis
+                        display: 'block', // Ensure Typography behaves as a block-level element for overflow control
+                      }}
+                    >
+                      {userInput.title}
+                    </Typography>
+                  </Tooltip>
                 }
                 id={`user-input-${userInput.id}`}
                 aria-label={`Details for ${userInput.title}`}
                 className={styles.userInputList__text}
               />
+
               <IconButton
                 className={styles.userInputList__icon}
                 onClick={handleOptionsIconClick}

--- a/client/components/layout/UserInputList.tsx
+++ b/client/components/layout/UserInputList.tsx
@@ -158,25 +158,38 @@ const UserInputList: React.FC<UserInputListProps> = ({
       >
         {inputHistory.slice(0, visibleItems).map((userInput) => {
           return (
-            <ListItemButton
-              id={userInput.id}
+            <Tooltip
+              title={userInput.title}
               key={userInput.id}
-              onClick={() => handleUserInputSelect(userInput)}
-              role='listitem'
-              aria-labelledby={`user-input-${userInput.id}`}
-              className={`${styles.userInputList__itemButton} ${
-                activeUserInput?.id === userInput.id
-                  ? styles.userInputList__itemButtonSelected
-                  : ''
-              }`}
+              placement='right'
+              slotProps={{
+                popper: {
+                  modifiers: [
+                    {
+                      name: 'offset',
+                      options: {
+                        offset: [0, -15],
+                      },
+                    },
+                  ],
+                },
+              }}
+              arrow
             >
-              <ListItemText
-                primary={
-                  <Tooltip
-                    title={userInput.title}
-                    placement='right'
-                    arrow
-                  >
+              <ListItemButton
+                id={userInput.id}
+                key={userInput.id}
+                onClick={() => handleUserInputSelect(userInput)}
+                role='listitem'
+                aria-labelledby={`user-input-${userInput.id}`}
+                className={`${styles.userInputList__itemButton} ${
+                  activeUserInput?.id === userInput.id
+                    ? styles.userInputList__itemButtonSelected
+                    : ''
+                }`}
+              >
+                <ListItemText
+                  primary={
                     <Typography
                       variant='caption'
                       noWrap
@@ -190,20 +203,20 @@ const UserInputList: React.FC<UserInputListProps> = ({
                     >
                       {userInput.title}
                     </Typography>
-                  </Tooltip>
-                }
-                id={`user-input-${userInput.id}`}
-                aria-label={`Details for ${userInput.title}`}
-                className={styles.userInputList__text}
-              />
+                  }
+                  id={`user-input-${userInput.id}`}
+                  aria-label={`Details for ${userInput.title}`}
+                  className={styles.userInputList__text}
+                />
 
-              <IconButton
-                className={styles.userInputList__icon}
-                onClick={handleOptionsIconClick}
-              >
-                <MoreVertIcon />
-              </IconButton>
-            </ListItemButton>
+                <IconButton
+                  className={styles.userInputList__icon}
+                  onClick={handleOptionsIconClick}
+                >
+                  <MoreVertIcon />
+                </IconButton>
+              </ListItemButton>
+            </Tooltip>
           );
         })}
       </List>

--- a/client/components/layout/UserInputList.tsx
+++ b/client/components/layout/UserInputList.tsx
@@ -197,8 +197,8 @@ const UserInputList: React.FC<UserInputListProps> = ({
                         overflow: 'hidden',
                         textOverflow: 'ellipsis',
                         whiteSpace: 'nowrap',
-                        maxWidth: '100%', // Ensure max width to trigger ellipsis
-                        display: 'block', // Ensure Typography behaves as a block-level element for overflow control
+                        maxWidth: '100%',
+                        display: 'block',
                       }}
                     >
                       {userInput.title}

--- a/client/components/layout/UserInputList.tsx
+++ b/client/components/layout/UserInputList.tsx
@@ -168,7 +168,7 @@ const UserInputList: React.FC<UserInputListProps> = ({
                     {
                       name: 'offset',
                       options: {
-                        offset: [0, -15],
+                        offset: [0, 5],
                       },
                     },
                   ],

--- a/client/components/layout/UserInputList.tsx
+++ b/client/components/layout/UserInputList.tsx
@@ -174,7 +174,8 @@ const UserInputList: React.FC<UserInputListProps> = ({
                 primary={
                   <Tooltip
                     title={userInput.title}
-                    placement='top'
+                    placement='right'
+                    arrow
                   >
                     <Typography
                       variant='caption'


### PR DESCRIPTION
<!--# Pull Request Template -->
I added a tooltip to the left sidebar for user input items so that when a user hovers over an item, the full text is displayed. This is especially useful for longer user inputs that are truncated with an ellipsis.

Screenshots:

Tooltip without scrollbar:
<img width="493" alt="Screen Shot 2024-09-30 at 1 57 10 PM" src="https://github.com/user-attachments/assets/69d95a81-192e-4021-a7eb-a86a76fa1876">

Tooltip with scrollbar:
<img width="753" alt="Screen Shot 2024-09-30 at 1 59 01 PM" src="https://github.com/user-attachments/assets/7b7bb00d-eb1b-4469-9bd5-9118986a016a">

<!--
Please include a summary of the change and which issue is fixed. Include relevant motivation and context. List any dependencies that are required for this change.

Linking Issues:
 - To associate this pull request with a GitHub issue within the same repository, use the "Fixes #IssueNumber" syntax.
 - For external issues, use Markdown links: [Issue Name](Issue Link).
-->

Fixes # (issue)

## Type of change

<!--Please delete options that are not relevant.-->

- [ ]  🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨  New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] Other 🗒️ ______________

## How Can this be tested? Testing Plan to review this PR

<!--Please provide a short testing plan for PR reviewers to verify the changes you made actually work and that no new bugs or errors are introduced. Provide simple and specific steps the reviewer can follow to test the changes you made.-->

- [x] Where in the app does this change take place?
- From the root dir, start up the app (both client and server)
- [x] What are the steps to test this change?
- Sign in as a user
- At the top left of the sidebar, click 'Explore a New Topic'
- Enter a very long input and click 'Generate' or click on one of the longer examples provided. E.g. 'Taxonomy of Living Organisms'
- The user input will generate on the main content page on the left sidebar underneath 'Recent' you'll see the user input
- Hover your mouse pointer over the text and then outside of the text (within the button)
- [x] What is the expected output?
- The tooltip will display


## Checklist:

<!--Before submitting your pull request, please review the following checklist:-->

- [x] I have performed a self-review of my own code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [x] I have reviewed the [**Security Best Practices Document**](./docs/SECURITY_BEST_PRACTICES.md).
- [x] I have followed the [**Naming Conventions Guide**](./docs/NAMING_CONVENTIONS_GUIDE.md) for my changes.
- [x] I have ensured that my pull request title is descriptive.

## Additional Information:

<!--Any additional information, configuration, or data that might be necessary to reproduce the issue or feature.-->
