### PR TITLE
Bugfix: React List Key Issue

### DIFF
--- a/server/controllers/linktaFlowController.ts
+++ b/server/controllers/linktaFlowController.ts
@@ -2,12 +2,12 @@ import type { Request, Response, NextFunction } from 'express';
 import log4js from 'log4js';
 import mongoose from 'mongoose';
 import type createLinktaFlowService from '@/services/linktaFlowService';
-import type { CustomNode, CustomEdge } from '@/types';
 import {
   CustomError,
   InternalServerError,
   LinktaFlowNotFoundError,
 } from '@/utils/customErrors';
+
 const logger = log4js.getLogger('[LinktaFlow Controller]');
 
 /**
@@ -41,23 +41,16 @@ const createLinktaFlowController = (
         await privateLinktaFlowService.fetchLinktaFlowByUserInputId(
           userInputObjectId,
         );
+
       logger.debug('linktaflow', linktaFlow);
+
       if (linktaFlow) {
         const { nodes, edges } = linktaFlow;
 
-        const mappedNodes = nodes.map((node: CustomNode) => ({
-          ...node._doc,
-          id: node.id,
-        }));
-
-        const mappedEdges = edges.map((edge: CustomEdge) => ({
-          ...edge._doc,
-        }));
-
         res.locals.linktaFlow = {
           userInputId,
-          nodes: mappedNodes,
-          edges: mappedEdges,
+          nodes,
+          edges,
         };
       } else {
         throw new LinktaFlowNotFoundError();

--- a/server/models/LinktaFlowModel.ts
+++ b/server/models/LinktaFlowModel.ts
@@ -4,7 +4,7 @@ import type { Node, Edge } from 'reactflow';
 
 // Define the Node schema
 const nodeSchema = new Schema<Node>({
-  id: { type: String },
+  id: { type: String, required: true },
   type: { type: String },
   position: {
     x: { type: Number },
@@ -38,6 +38,7 @@ const nodeSchema = new Schema<Node>({
 
 // Define the Edge schema
 const edgeSchema = new Schema<Edge>({
+  id: { type: String, required: true },
   source: { type: String, required: true },
   target: { type: String, required: true },
   type: { type: String },

--- a/server/services/linktaFlowService.ts
+++ b/server/services/linktaFlowService.ts
@@ -33,17 +33,10 @@ const createLinktaFlowService = () => {
         edges,
       });
 
-      const linktaFlowData = {
-        userId,
-        userInputId,
-        nodes,
-        edges,
-      };
+      const linktaFlowData = { userId, userInputId, nodes, edges };
 
-      // Create LinktaFlow in DB
       const newLinktaFlow = await LinktaFlowModel.create(linktaFlowData);
 
-      // Update userInput with the corresponding linktaFlowId
       await UserInputModel.findByIdAndUpdate(userInputId, {
         $set: { linktaFlowId: newLinktaFlow._id },
       });

--- a/server/types/datamodels.d.ts
+++ b/server/types/datamodels.d.ts
@@ -10,70 +10,8 @@ export type UserInput = {
   updatedAt: Date;
 };
 
-export type CustomNode = {
-  _id: string;
-  id: string;
-  type: string;
-  position: { x: number; y: number };
-  data: { label: string };
-  style?: object;
-  className?: string;
-  hidden?: boolean;
-  selected?: boolean;
-  draggable?: boolean;
-  dragging?: boolean;
-  selectable?: boolean;
-  connectable?: boolean;
-  deletable?: boolean;
-  dragHandle?: string;
-  width?: number;
-  height?: number;
-  parentId?: string;
-  zIndex?: number;
-  extent?: 'parent' | null;
-  expandParent?: boolean;
-  sourcePosition?: 'left' | 'right' | 'top' | 'bottom';
-  targetPosition?: 'left' | 'right' | 'top' | 'bottom';
-  ariaLabel?: string;
-  focusable?: boolean;
-  resizing?: boolean;
-  _doc?: CustomNode;
-};
-
-export type CustomEdge = {
-  _id: string;
-  id: string;
-  source: string;
-  target: string;
-  type?: string;
-  sourceHandle?: string;
-  targetHandle?: string;
-  style?: object;
-  animated?: boolean;
-  hidden?: boolean;
-  deletable?: boolean;
-  className?: string;
-  selected?: boolean;
-  zIndex?: number;
-  ariaLabel?: string;
-  focusable?: boolean;
-  label?: string;
-  labelStyle?: object;
-  labelShowBg?: boolean;
-  labelBgStyle?: object;
-  labelBgPadding?: number[];
-  labelBgBorderRadius?: number;
-  pathOptions?: {
-    offset?: number;
-    borderRadius?: number;
-    curvature?: number;
-  };
-  _doc?: CustomEdge;
-};
-
 export type LinktaFlow = {
   _id: Types.ObjectId;
-  // id: string;
   userId: string;
   nodes: CustomNode[];
   edges: CustomEdge[];


### PR DESCRIPTION
<!--# Pull Request Template -->
## Description
This PR fixes the console warning related to missing "key" prop in EdgeRenderer by ensuring all edges have unique keys, addressing the React Flow rendering issue.

- Removed unnecessary typing and ID mapping.
- Added `id` prop to the edge schema.

Fixes #319 

## Type of change

<!--Please delete options that are not relevant.-->

- [X]  🐛 Bug fix (non-breaking change which fixes an issue)

## How Can this be tested? Testing Plan to review this PR
- Spin up the app
- Create a new LinktaFlow
- Observe 
    - React Query:id in both nodes & edges
![image](https://github.com/user-attachments/assets/9ed91b61-aa7f-4ce7-a5d5-1e4668816a9b)
    - Console: no warning about unique key


## Checklist:

<!--Before submitting your pull request, please review the following checklist:-->

- [X] I have performed a self-review of my own code.
- [X] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [X] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [X] I have reviewed the [**Security Best Practices Document**](./docs/SECURITY_BEST_PRACTICES.md).
- [X] I have followed the [**Naming Conventions Guide**](./docs/NAMING_CONVENTIONS_GUIDE.md) for my changes.
- [X] I have ensured that my pull request title is descriptive.

## Additional Information:
- LinktaFLow validation for LLM response will be implemented in a separate PR 
