### PR TITLE
Update styles on text inputs for auth pages

### DIFF
--- a/client/features/auth-pages/ForgotPasswordPage.tsx
+++ b/client/features/auth-pages/ForgotPasswordPage.tsx
@@ -42,7 +42,7 @@ const ForgotPasswordPage = () => {
         console.error('Failed to send password reset email', error.message);
 
         showNotification(
-          "FWe couldn't send the password reset email. Please verify your email address and try again.",
+          "We couldn't send the password reset email. Please verify your email address and try again.",
           'error',
           {
             duration: 6000,
@@ -67,8 +67,8 @@ const ForgotPasswordPage = () => {
         mb={6}
         variant='body1'
       >
-        Please provide the email you signed up with. We will send a secure
-        linkto reset your account password.
+        Please provide the email you signed up with. We will send a secure link
+        to reset your account password.
       </Typography>
 
       <form
@@ -82,6 +82,12 @@ const ForgotPasswordPage = () => {
           {...register('email')}
           error={!!errors.email}
           helperText={errors.email?.message}
+          className={`${styles.textInput}`}
+          sx={{
+            '& .MuiInput-underline:before': {
+              borderBottomColor: '#D9D9D9 ',
+            },
+          }}
         ></TextField>
         <Button
           variant='contained'

--- a/client/features/auth-pages/SignInPage.tsx
+++ b/client/features/auth-pages/SignInPage.tsx
@@ -135,15 +135,27 @@ const SignInPage = () => {
             label='email address'
             variant='standard'
             type='email'
+            className={`${styles.textInput}`}
             {...register('email')}
             error={!!errors.email}
             helperText={errors.email?.message}
+            sx={{
+              '& .MuiInput-underline:before': {
+                borderBottomColor: '#D9D9D9',
+              },
+            }}
           ></TextField>
           <TextField
             label='password'
-            type='password'
             variant='standard'
+            type='password'
+            className={`${styles.textInput}`}
             {...register('password')}
+            sx={{
+              '& .MuiInput-underline:before': {
+                borderBottomColor: '#D9D9D9 ',
+              },
+            }}
           ></TextField>
           <Button
             type='submit'

--- a/client/features/auth-pages/SignUpPage.tsx
+++ b/client/features/auth-pages/SignUpPage.tsx
@@ -155,6 +155,12 @@ const SignUpPage = () => {
             {...register('name')}
             error={!!errors.name}
             helperText={errors.name?.message}
+            className={`${styles.textInput}`}
+            sx={{
+              '& .MuiInput-underline:before': {
+                borderBottomColor: '#D9D9D9 ',
+              },
+            }}
           ></TextField>
           <TextField
             label='email address'
@@ -163,12 +169,24 @@ const SignUpPage = () => {
             {...register('email')}
             error={!!errors.email}
             helperText={errors.email?.message}
+            className={`${styles.textInput}`}
+            sx={{
+              '& .MuiInput-underline:before': {
+                borderBottomColor: '#D9D9D9 ',
+              },
+            }}
           ></TextField>
           <TextField
             label='password'
             type='password'
             variant='standard'
             {...register('password')}
+            className={`${styles.textInput}`}
+            sx={{
+              '& .MuiInput-underline:before': {
+                borderBottomColor: '#D9D9D9 ',
+              },
+            }}
           ></TextField>
           <Button
             type='submit'

--- a/client/styles/UserInputView.module.css
+++ b/client/styles/UserInputView.module.css
@@ -39,12 +39,6 @@
   color: var(--primary-contrastText);
 }
 
-.userInputCheckbox {
-}
-
-.userInputDisclaimer {
-}
-
 .userInputSubmitButton {
   margin-top: 30px;
   height: 40px;
@@ -76,7 +70,7 @@
 .topicsButton {
   opacity: 0.8;
   background-color: rgba(128, 128, 128, 0.318);
-  border: 1px solid rgba(255, 255, 255, 0.66);
+  border: 1px solid var(--light-gray);
   width: 100%;
 }
 

--- a/client/styles/layout/AuthStyles.module.css
+++ b/client/styles/layout/AuthStyles.module.css
@@ -6,8 +6,7 @@
   padding-top: 2dvh;
   gap: 3dvh;
 
-  & p,
-  h6 {
+  & p, h3, h6 {
     color: var(--light-gray);
   }
 
@@ -16,10 +15,6 @@
     text-decoration: underline;
     margin: 0px 5px;
   }
-}
-
-.headingText {
-  color: var(--light-gray);
 }
 
 .buttonWrapper {
@@ -36,7 +31,8 @@
   color: black;
   background-color: var(--light-gray);
   &:hover {
-    color: var(--secondary-dark);
+    background-color: var(--medium-gray);
+    color: var(--light-gray);
   }
 }
 
@@ -50,6 +46,10 @@
   display: flex;
   flex-direction: column;
   gap: 5dvh;
+}
+
+.textInput > label {
+  color: var(--light-gray);
 }
 
 .formSubmitButton {

--- a/client/styles/layout/AuthStyles.module.css
+++ b/client/styles/layout/AuthStyles.module.css
@@ -6,7 +6,9 @@
   padding-top: 2dvh;
   gap: 3dvh;
 
-  & p, h3, h6 {
+  & p,
+  h3,
+  h6 {
     color: var(--light-gray);
   }
 

--- a/client/utils/customTheme.ts
+++ b/client/utils/customTheme.ts
@@ -37,6 +37,7 @@ const themeOptions: ThemeOptions = {
         ':root': {
           '--divider': '#4F5D66',
           '--light-gray': '#D9D9D9',
+          '--medium-gray': '#7D7D7D',
           '--link-text': '#7CD2D7',
           '--primary-light': '#3d8590',
           '--primary-main': '#23616a',


### PR DESCRIPTION
<!--# Pull Request Template -->
Update text field styling to match Figma design.
Note: I was unable to find a selector for the MUI TextField border-bottom to use with CSS modules. Was forced to use in-line styles for the underline color.
Note: In practice, I felt the lighter gray color looked better than the specific shade from the Figma design.

Figma:
![image](https://github.com/user-attachments/assets/37d478b6-839c-436f-868b-176c4ff29121)


![image](https://github.com/user-attachments/assets/41a7f02b-a577-4cbd-84bf-e08286e34aed)

![image](https://github.com/user-attachments/assets/2862ef9b-0093-4401-add8-a53c5f2b8922)

![image](https://github.com/user-attachments/assets/c6a0db33-211f-47fe-97c8-ffe9a40bb8d9)


<!--
Please include a summary of the change and which issue is fixed. Include relevant motivation and context. List any dependencies that are required for this change.

Linking Issues:
 - To associate this pull request with a GitHub issue within the same repository, use the "Fixes #IssueNumber" syntax.
 - For external issues, use Markdown links: [Issue Name](Issue Link).
-->

Fixes #386 

## Type of change

<!--Please delete options that are not relevant.-->


- [x] Other 🗒️ Styling update



## Checklist:

<!--Before submitting your pull request, please review the following checklist:-->

- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.
- [x] I have ensured that my pull request title is descriptive.

