### PR TITLE
Refactor Dialog Components for Better Reusability and Accessibility

### DIFF
--- a/client/components/common/LinktaDialog.tsx
+++ b/client/components/common/LinktaDialog.tsx
@@ -1,0 +1,115 @@
+import React, { useEffect, useRef } from 'react';
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  Typography,
+  Box,
+} from '@mui/material';
+import styles from '@styles/LinktaDialog.module.css';
+
+interface LinktaDialogProps {
+  isOpen: boolean;
+  title: string;
+  content: React.ReactNode;
+  confirmText: string;
+  cancelText: string;
+  icon?: React.ReactNode;
+  onConfirm: () => void;
+  onCancel: () => void;
+  confirmButtonClass?: string;
+}
+
+/**
+ * LinktaDialog is a reusable dialog component that handles user confirmations.
+ * It contains a title, content area, and actions for confirming or canceling.
+ *
+ * @param {boolean} isOpen - Controls the visibility of the dialog.
+ * @param {string} title - Title of the dialog.
+ * @param {React.ReactNode} content - The content displayed inside the dialog.
+ * @param {string} confirmText - Text for the confirm button.
+ * @param {string} cancelText - Text for the cancel button.
+ * @param {React.ReactNode} [icon] - Optional icon displayed next to the title.
+ * @param {() => void} onConfirm - Function called when the user confirms the action.
+ * @param {() => void} onCancel - Function called when the user cancels the action.
+ * @param {string} [confirmButtonClass] - Optional custom class for the confirm button.
+ *
+ * @returns {JSX.Element} The rendered dialog component.
+ */
+const LinktaDialog: React.FC<LinktaDialogProps> = ({
+  isOpen,
+  title,
+  content,
+  confirmText,
+  cancelText,
+  icon,
+  onConfirm,
+  onCancel,
+  confirmButtonClass,
+}) => {
+  const dialogRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    /**
+     * Automatically focus on the first focusable element (buttons, inputs, links) when the dialog opens.
+     * This enhances accessibility for keyboard users.
+     */
+    if (isOpen && dialogRef.current) {
+      const focusableElements = dialogRef.current.querySelectorAll<HTMLElement>(
+        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+      );
+      if (focusableElements.length > 0) {
+        focusableElements[0].focus(); // Set focus to the first focusable element
+      }
+    }
+  }, [isOpen]);
+
+  return (
+    <Dialog
+      open={isOpen}
+      onClose={onCancel}
+      aria-labelledby='linkta-dialog-title'
+      aria-describedby='linkta-dialog-content'
+      role='dialog'
+      aria-modal='true'
+      ref={dialogRef}
+      classes={{ paper: styles.dialog }}
+    >
+      <DialogTitle
+        id='linkta-dialog-title'
+        className={styles.dialogTitle}
+      >
+        <Box className={styles.dialogHeader}>
+          {icon}
+          <Typography className={styles.dialogTitleText}>{title}</Typography>
+        </Box>
+      </DialogTitle>
+      <DialogContent
+        id='linkta-dialog-content'
+        className={styles.dialogContent}
+      >
+        {content}
+      </DialogContent>
+      <DialogActions className={styles.dialogActions}>
+        <Button
+          onClick={onCancel}
+          className={`${styles.buttonBase} ${styles.cancelButton}`}
+          aria-label='Cancel the dialog'
+        >
+          {cancelText}
+        </Button>
+        <Button
+          onClick={onConfirm}
+          className={`${styles.buttonBase} ${confirmButtonClass || styles.confirmButton}`}
+          aria-label={confirmText}
+        >
+          {confirmText}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default LinktaDialog;

--- a/client/components/layout/DeleteDialog.tsx
+++ b/client/components/layout/DeleteDialog.tsx
@@ -1,74 +1,47 @@
 import React from 'react';
-import {
-  Dialog,
-  DialogTitle,
-  DialogContent,
-  DialogActions,
-  Button,
-  Typography,
-  Box,
-} from '@mui/material';
-import styles from '@styles/layout/DeleteDialog.module.css';
+import { Typography } from '@mui/material';
 import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline';
+import LinktaDialog from '@components/common/LinktaDialog';
+import styles from '@styles/layout/DeleteDialog.module.css';
 
 interface DeleteDialogProps {
   isOpen: boolean;
+  currentTitle: string;
   onDelete: () => void;
   onCancel: () => void;
 }
 
 const DeleteDialog: React.FC<DeleteDialogProps> = ({
   isOpen,
+  currentTitle,
   onDelete,
   onCancel,
 }) => {
+  const content = (
+    <Typography className={styles.deleteText}>
+      Are you sure you want to delete{' '}
+      <Typography
+        component='span'
+        fontWeight='bold'
+      >
+        {currentTitle}
+      </Typography>
+      ?
+    </Typography>
+  );
+
   return (
-    <Dialog
-      open={isOpen}
-      onClose={onCancel}
-      classes={{ paper: styles.dialog }}
-      aria-labelledby='delete-dialog-title'
-      aria-describedby='delete-dialog-description'
-    >
-      <DialogTitle
-        id='delete-dialog-title'
-        className={styles.dialogTitle}
-      >
-        <Box className={styles.titleContainer}>
-          <ErrorOutlineIcon className={styles.icon} />
-          <Typography className={styles.titleText}>
-            Delete This Input
-          </Typography>
-        </Box>
-      </DialogTitle>
-      <DialogContent
-        id='delete-dialog-description'
-        className={styles.dialogContent}
-      >
-        <Box className={styles.textField}>
-          <Typography className={styles.boxText}>
-            By deleting this input, you are also deleting the Linkta flow
-            diagram associated with it. This action cannot be undone.
-          </Typography>
-        </Box>
-      </DialogContent>
-      <DialogActions className={styles.buttonGroup}>
-        <Button
-          onClick={onDelete}
-          className={styles.deleteButton}
-          aria-label='Delete input'
-        >
-          <Typography variant='button'>Delete</Typography>
-        </Button>
-        <Button
-          onClick={onCancel}
-          className={styles.cancelButton}
-          aria-label='Cancel delete'
-        >
-          <Typography variant='button'>Cancel</Typography>
-        </Button>
-      </DialogActions>
-    </Dialog>
+    <LinktaDialog
+      isOpen={isOpen}
+      title='Delete Input'
+      content={content}
+      confirmText='Delete'
+      cancelText='Cancel'
+      icon={<ErrorOutlineIcon className={styles.deleteIcon} />}
+      onConfirm={onDelete}
+      onCancel={onCancel}
+      confirmButtonClass={styles.deleteConfirmButton}
+    />
   );
 };
 

--- a/client/components/layout/RenameDialog.tsx
+++ b/client/components/layout/RenameDialog.tsx
@@ -1,29 +1,17 @@
 import React, { useEffect } from 'react';
-import {
-  Dialog,
-  DialogTitle,
-  DialogContent,
-  TextField,
-  DialogActions,
-  Button,
-  Typography,
-  FormControl,
-  FormHelperText,
-} from '@mui/material';
 import { useForm, Controller } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
-import styles from '@styles/layout/RenameDialog.module.css';
+import { TextField, FormControl, FormHelperText } from '@mui/material';
+import EditIcon from '@mui/icons-material/Edit';
+import LinktaDialog from '@components/common/LinktaDialog';
 import { userInputTitleSchema } from '@validators/userInputSchemas';
+import styles from '@styles/layout/RenameDialog.module.css';
 
 interface RenameDialogProps {
   isOpen: boolean;
   currentTitle: string;
   onSave: (newTitle: string) => void;
   onCancel: () => void;
-}
-
-interface FormData {
-  title: string;
 }
 
 const RenameDialog: React.FC<RenameDialogProps> = ({
@@ -47,84 +35,61 @@ const RenameDialog: React.FC<RenameDialogProps> = ({
     setValue('title', currentTitle);
   }, [currentTitle, setValue]);
 
-  const handleSaveClick = (data: FormData) => {
-    onSave(data.title);
-  };
+  const handleSaveClick = (data: { title: string }) => onSave(data.title);
 
-  const handleCancelClick = () => {
-    reset({ title: currentTitle });
-    onCancel();
-  };
+  const formContent = (
+    <form
+      onSubmit={handleSubmit(handleSaveClick)}
+      className={styles.renameForm}
+      aria-live='polite'
+    >
+      <FormControl
+        error={!!errors.title}
+        fullWidth
+      >
+        <Controller
+          name='title'
+          control={control}
+          render={({ field }) => (
+            <TextField
+              {...field}
+              fullWidth
+              variant='outlined'
+              aria-required='true'
+              aria-invalid={!!errors.title}
+              aria-describedby='title-error'
+              className={styles.textField}
+            />
+          )}
+        />
+        {errors.title && (
+          <FormHelperText
+            id='title-error'
+            className={styles.formError}
+            aria-live='assertive'
+          >
+            {errors.title.message}
+          </FormHelperText>
+        )}
+      </FormControl>
+    </form>
+  );
 
   return (
-    <Dialog
-      open={isOpen}
-      onClose={handleCancelClick}
-      classes={{ paper: styles.dialog }}
-      aria-labelledby='rename-dialog-title'
-      aria-describedby='rename-dialog-description'
-    >
-      <DialogTitle
-        id='rename-dialog-title'
-        className={styles.dialogTitle}
-      >
-        <Typography>Current Title:</Typography>
-      </DialogTitle>
-      <DialogContent
-        id='rename-dialog-description'
-        className={styles.dialogContent}
-      >
-        <form onSubmit={handleSubmit(handleSaveClick)}>
-          <FormControl
-            error={!!errors.title}
-            fullWidth
-          >
-            <Controller
-              name='title'
-              control={control}
-              render={({ field }) => (
-                <TextField
-                  {...field}
-                  margin='none'
-                  label=''
-                  type='text'
-                  fullWidth
-                  variant='outlined'
-                  className={styles.textField}
-                  aria-required='true'
-                  aria-invalid={!!errors.title}
-                />
-              )}
-            />
-            {errors.title && (
-              <FormHelperText
-                error
-                id='title-error-text'
-              >
-                {errors.title.message}
-              </FormHelperText>
-            )}
-          </FormControl>
-
-          <DialogActions className={styles.buttonGroup}>
-            <Button
-              onClick={handleCancelClick}
-              className={styles.cancelButton}
-              aria-label='Cancel renaming'
-            >
-              <Typography variant='button'>Cancel</Typography>
-            </Button>
-            <Button
-              type='submit'
-              className={styles.saveButton}
-              aria-label='Save new title'
-            >
-              <Typography variant='button'>Save</Typography>
-            </Button>
-          </DialogActions>
-        </form>
-      </DialogContent>
-    </Dialog>
+    <LinktaDialog
+      isOpen={isOpen}
+      title='Rename Title'
+      content={formContent}
+      confirmText='Save'
+      cancelText='Cancel'
+      icon={<EditIcon className={styles.editIcon} />}
+      onConfirm={handleSubmit(handleSaveClick)}
+      onCancel={() => {
+        reset({ title: currentTitle });
+        onCancel();
+      }}
+      confirmButtonClass={styles.renameConfirmButton}
+    />
   );
 };
 

--- a/client/components/layout/UserInputList.tsx
+++ b/client/components/layout/UserInputList.tsx
@@ -240,6 +240,7 @@ const UserInputList: React.FC<UserInputListProps> = ({
       {activeUserInput && (
         <DeleteDialog
           isOpen={isDeletionDialogOpen}
+          currentTitle={activeUserInput.title}
           onDelete={handleInputDeletion}
           onCancel={() => setIsDeletionDialogOpen(false)}
         />

--- a/client/styles/LinktaDialog.module.css
+++ b/client/styles/LinktaDialog.module.css
@@ -1,0 +1,66 @@
+.dialog {
+  max-width: 28rem;
+  width: 60%;
+  background-color: var(--secondary-contrastText);
+  border-radius: 8px;
+  padding: 0.625rem;
+  min-height: 11rem;
+}
+
+.dialogHeader {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+}
+
+.dialogTitle {
+  padding: 0.5rem 0;
+}
+
+.dialogTitleText {
+  color: var(--light-gray);
+  font-size: 1.25rem;
+  margin-left: 0.5rem;
+}
+
+.dialogContent {
+  display: flex;
+  justify-content: center;
+  flex-direction: column;
+  flex-grow: 1;
+  text-align: center;
+  min-height: 5rem;
+  width: 100%;
+}
+
+.dialogActions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+/* Base button styles */
+.buttonBase {
+  width: 6.25rem;
+  height: 2rem;
+  border-radius: 16.5px;
+  text-align: center;
+  border: 1px solid transparent;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-size: 0.85rem;
+  font-weight: bold;
+  transition: background-color 0.3s ease;
+  cursor: pointer;
+}
+
+.cancelButton {
+  background-color: var(--light-gray);
+  color: var(--primary-dark);
+}
+
+.cancelButton:hover {
+  background-color: #bdbdbd;
+  color: var(--primary-dark);
+}

--- a/client/styles/layout/DeleteDialog.module.css
+++ b/client/styles/layout/DeleteDialog.module.css
@@ -1,118 +1,22 @@
-.dialog {
-  max-width: 500px;
-  width: 70%;
-  background-color: var(--secondary-contrastText);
-  border: solid 1px #ff1b1b;
-  border-radius: 10px;
-  padding: 10px;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-}
-
-.dialog-content {
-  padding: 0;
-  margin: 0 10px;
-}
-
-.dialogTitle {
-  color: var(--light-gray);
-  font-size: medium;
-  padding: 10px;
+.deleteText {
+  font-size: 0.9rem;
   text-align: center;
-  justify-content: center;
 }
 
-.titleContainer {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.icon {
+.deleteIcon {
+  font-size: 2rem;
   color: red;
-  font-size: 2.5rem;
-  margin-right: 5px;
-  opacity: 0.9;
 }
 
-.titleText {
+.deleteConfirmButton {
+  background-color: red;
   color: var(--light-gray);
-  font-size: 1.5rem;
 }
 
-.textField {
-  width: 100%;
-  background-color: var(--hover-background-color);
-  border-radius: 10px;
-  padding: 10px;
-  box-sizing: border-box;
+.deleteConfirmButton:hover {
+  background-color: darkred;
 }
 
-.boxText {
-  font-size: 0.75rem;
-  text-align: center;
-  padding: 5px;
-}
-
-.buttonGroup {
-  display: flex;
-  justify-content: space-between;
-  gap: 8px;
-  padding: 25px 10px;
-}
-
-.cancelButton,
-.deleteButton {
-  border-radius: 50px;
-  border: solid 1px var(--secondary-main);
-  width: 100px;
-}
-
-.cancelButton {
-  color: var(--text-primary);
-}
-
-.cancelButton:hover {
-  background-color: var(--secondary-main);
-  color: var(--primary-dark);
-}
-
-.deleteButton {
-  color: var(--primary-dark);
-  background-color: var(--secondary-main);
-}
-
-.deleteButton:hover {
-  background-color: var(--secondary-dark);
-}
-
-@media (max-width: 1200px) {
-  .dialog {
-    width: 60%;
-  }
-}
-
-@media (max-width: 900px) {
-  .dialog {
-    width: 70%;
-  }
-}
-
-@media (max-width: 600px) {
-  .dialog {
-    width: 80%;
-  }
-}
-
-@media (max-width: 400px) {
-  .dialog {
-    width: 90%;
-  }
-}
-
-@media (max-width: 350px) {
-  .dialog {
-    display: none;
-  }
+button:focus {
+  outline: 2px solid var(--secondary-main);
 }

--- a/client/styles/layout/RenameDialog.module.css
+++ b/client/styles/layout/RenameDialog.module.css
@@ -1,103 +1,34 @@
-.dialog {
-  max-width: 500px;
-  width: 70%;
-  background-color: var(--secondary-contrastText);
-  border-radius: 10px;
-  padding: 20px 10px;
+.renameForm {
   display: flex;
   flex-direction: column;
-  justify-content: center;
-}
-
-.dialog-content {
-  padding: 0;
-  margin: 10px;
-}
-
-.dialogTitle {
-  color: var(--light-gray);
-  font-size: medium;
-  padding: 10px 10px 0 10px;
+  gap: 0.75rem;
 }
 
 .textField {
   width: 100%;
   background-color: var(--hover-background-color);
-  border-radius: 10px;
-  align-items: center;
+  border-radius: 0.25rem;
 }
 
-.textField :global(.MuiFormHelperText-root) {
+.formError {
   color: red;
-  font-size: 0.75rem;
-  line-height: 1rem;
-  margin-top: 5px;
+  font-size: 0.8rem;
 }
 
-.textField:hover
-  :global(.MuiOutlinedInput-root)
-  :global(.MuiOutlinedInput-notchedOutline) {
-  border: solid 1px var(--secondary-main);
+.editIcon {
+  font-size: 1.6rem;
+  color: var(--light-gray);
 }
 
-.buttonGroup {
-  display: flex;
-  justify-content: flex-end;
-  gap: 8px;
-  padding: 25px 10px;
-}
-
-.cancelButton,
-.saveButton {
-  border-radius: 50px;
-  border: solid 1px var(--secondary-main);
-  width: 100px;
-}
-
-.cancelButton {
-  color: var(--text-primary);
-}
-
-.cancelButton:hover {
+.renameConfirmButton {
   background-color: var(--secondary-main);
   color: var(--primary-dark);
 }
 
-.saveButton {
-  color: var(--primary-dark);
-  background-color: var(--secondary-main);
-}
-
-.saveButton:hover {
+.renameConfirmButton:hover {
   background-color: var(--secondary-dark);
 }
 
-@media (max-width: 1200px) {
-  .dialog {
-    width: 60%;
-  }
-}
-
-@media (max-width: 900px) {
-  .dialog {
-    width: 70%;
-  }
-}
-
-@media (max-width: 600px) {
-  .dialog {
-    width: 80%;
-  }
-}
-
-@media (max-width: 400px) {
-  .dialog {
-    width: 90%;
-  }
-}
-
-@media (max-width: 350px) {
-  .dialog {
-    display: none;
-  }
+input:focus {
+  outline: 2px solid var(--secondary-main);
 }

--- a/client/validators/userInputSchemas.ts
+++ b/client/validators/userInputSchemas.ts
@@ -27,7 +27,7 @@ export const userInputTitleSchema = z.object({
     .string()
     .min(1, 'Input title is required')
     .max(15, {
-      message: 'Title must be less than 15 characters in length!',
+      message: 'Title must be less than 15 characters in length',
     })
     .refine((val) => hasHtmlChars(val), {
       message:


### PR DESCRIPTION
<!--# Pull Request Template -->
## Description

- Created a reusable `LinktaDialog` component
- Added focus management in `LinktaDialog` to ensure accessibility
- Improved hover and focus states for `TextField` and buttons to align with WCAG 2.2 standards https://www.w3.org/WAI/WCAG22/Understanding/focus-appearance.html
- Added edit icon for `RenameDialog`
- Simplified wordings for titles and content
- Refactored CSS (more DRY, reduced Dialog size by around 15%, change `delete` button color to red)

Fixes #312 #354 

## Type of change
- [X] Other 🗒️ Refactoring

## How Can this be tested? Testing Plan to review this PR
- Spin up app
- Click Sidenav -> Rename
- Click Sidenav -> Delete
![image](https://github.com/user-attachments/assets/c933998b-4c39-41d5-a782-157065be5206)
![image](https://github.com/user-attachments/assets/5060c3c6-c448-4f68-9b7a-ec5765b6868d)

## Checklist:

<!--Before submitting your pull request, please review the following checklist:-->

- [X] I have performed a self-review of my own code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [X] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [X] I have reviewed the [**Security Best Practices Document**](./docs/SECURITY_BEST_PRACTICES.md).
- [X] I have followed the [**Naming Conventions Guide**](./docs/NAMING_CONVENTIONS_GUIDE.md) for my changes.
- [X] I have ensured that my pull request title is descriptive.
